### PR TITLE
fix(docs): types for maxWidth and maxHeight props

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class MyComponent extends React.Component {
 ## Props
   - `src - {String}` – **required** – Image source.
   - `color - {String}` – **required** – Color you want to tint your icon.
-  - `maxWidth - {String} && maxHeight - {String}` – maxWidth + maxHeight for the icon
+  - `maxWidth - {Number} && maxHeight - {Number}` – maxWidth + maxHeight for the icon
   - `fallback - {ReactComponent}` – Fallback component used during the load period and on SSR;
   
 ## Contributing

--- a/src/index.js
+++ b/src/index.js
@@ -59,8 +59,8 @@ IconTint.propTypes = {
   src: PropTypes.string.isRequired,
   color: PropTypes.string.isRequired,
   fallback: PropTypes.node,
-  maxWidth: PropTypes.string,
-  maxHeight: PropTypes.string
+  maxWidth: PropTypes.number,
+  maxHeight: PropTypes.number
 };
 
 export default IconTint;


### PR DESCRIPTION
These props must be numbers, but the current docs suggest they should be strings.